### PR TITLE
[Feat] Search화면 카드에서 Detail로 가는 Navigation추가

### DIFF
--- a/BookfelTower/BookfelTower.xcodeproj/project.pbxproj
+++ b/BookfelTower/BookfelTower.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		21C110372A26EE8F002CC10C /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C110362A26EE8F002CC10C /* LibraryView.swift */; };
 		21C8BE682A0CCDE700308BEF /* SearchPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21C8BE672A0CCDE700308BEF /* SearchPageView.swift */; };
 		21EB4E322A1DD6BF00E12B12 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		577A69BC2A27066800F1C42F /* SampleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577A69BB2A27066800F1C42F /* SampleDetailView.swift */; };
 		57E8A2572A0B32C300AFFEAA /* BookfelTowerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E8A2562A0B32C300AFFEAA /* BookfelTowerApp.swift */; };
 		57E8A25B2A0B32C400AFFEAA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57E8A25A2A0B32C400AFFEAA /* Assets.xcassets */; };
 		57E8A25E2A0B32C400AFFEAA /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57E8A25D2A0B32C400AFFEAA /* Preview Assets.xcassets */; };
@@ -25,6 +26,7 @@
 		214099AF2A0B649800F846AC /* DetailPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPageView.swift; sourceTree = "<group>"; };
 		21C110362A26EE8F002CC10C /* LibraryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		21C8BE672A0CCDE700308BEF /* SearchPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPageView.swift; sourceTree = "<group>"; };
+		577A69BB2A27066800F1C42F /* SampleDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDetailView.swift; sourceTree = "<group>"; };
 		57A2C7362A1DE44F00396FC2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		57E8A2532A0B32C300AFFEAA /* BookfelTower.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BookfelTower.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		57E8A2562A0B32C300AFFEAA /* BookfelTowerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookfelTowerApp.swift; sourceTree = "<group>"; };
@@ -52,6 +54,7 @@
 			isa = PBXGroup;
 			children = (
 				214099AF2A0B649800F846AC /* DetailPageView.swift */,
+				577A69BB2A27066800F1C42F /* SampleDetailView.swift */,
 			);
 			path = DetailPage;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 				21C110372A26EE8F002CC10C /* LibraryView.swift in Sources */,
 				57E8A2682A0B336900AFFEAA /* BookModel.swift in Sources */,
 				57E8A26C2A0B338800AFFEAA /* HomeView.swift in Sources */,
+				577A69BC2A27066800F1C42F /* SampleDetailView.swift in Sources */,
 				57E8A2572A0B32C300AFFEAA /* BookfelTowerApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BookfelTower/BookfelTower/Home/DetailPage/DetailPageView.swift
+++ b/BookfelTower/BookfelTower/Home/DetailPage/DetailPageView.swift
@@ -6,28 +6,31 @@
 //
 
 import SwiftUI
+enum CurrentInfo{
+    case bookInfo
+    case memo
+}
 
 struct DetailPageView: View {
-    enum CurrentInfo{
-        case bookInfo
-        case memo
-    }
-    @State private var currentInfo: CurrentInfo = .bookInfo
-    let title: String
-    let author: String
-    let pageNumber: String
-    let coverUrl: String
-    let description: String
-    let isbn: String
-    let publisher: String
-    let readingStatus: ReadStatus
-    let currentReadingPage: Int
-    let expectedScore: Int
-    let startDate: Date?
-    let endDate: Date?
+    //ISBN만 받아와서 새로 API 호출 할 것
+    let isbn: String?
+    //일단 예시로 서치페이지에서 받아온것. API에서 새로 받은 데이터로 가능한 고화질의 이미지가 필요함.
+    let coverUrl: String?
+    
+    //private으로 할 시 parent view에서 initialize 불가능했기때문에 internal로 바꿈
+    @State internal var currentInfo: CurrentInfo = .bookInfo
+    internal var title: String?
+    internal var author: String?
+    internal var pageNumber: String?
+    internal var description: String?
+    internal var publisher: String?
+    internal var readingStatus: ReadStatus?
+    internal var currentReadingPage: Int?
+    internal var expectedScore: Int?
+    internal var startDate: Date?
+    internal var endDate: Date?
     
     var body: some View {
-        
         TopAppBar()
         ScrollView{
             LazyVStack{
@@ -44,10 +47,10 @@ struct DetailPageView: View {
                 if currentInfo == .bookInfo {
                     HStack{
                         VStack(alignment: .leading, spacing: 3){
-                            LabelInfo(title: "책 소개", subTitle: description)
-                            LabelInfo(title: "출판사", subTitle: publisher)
-                            LabelInfo(title: "ISBN", subTitle: isbn)
-                            LabelInfo(title: "페이지", subTitle: pageNumber)
+                            LabelInfo(title: "책 소개", subTitle: description ?? "")
+                            LabelInfo(title: "출판사", subTitle: publisher ?? "")
+                            LabelInfo(title: "ISBN", subTitle: isbn ?? "")
+                            LabelInfo(title: "페이지", subTitle: pageNumber ?? "")
                             HStack{
                                 Text("책 정보 수정")
                                     .underline()
@@ -80,16 +83,16 @@ struct DetailPageView: View {
     }
     
     @ViewBuilder
-    private var BookDetailVStack: some View{
+    var BookDetailVStack: some View{
         VStack{
-            Text(title).padding(.top, 10)
-            AsyncImage(url: URL(string: coverUrl)) { image in image
+            Text(title ?? "").padding(.top, 10)
+            AsyncImage(url: URL(string: coverUrl ?? "")) { image in image
                     .resizable()
                     .frame(width: 150, height: 200)
             } placeholder: {
                 ProgressView()
             }
-            Text("\(author) (\(pageNumber)p)")
+            Text("\(author ?? "") (\(pageNumber ?? "")p)")
             if readingStatus == .done
             {
                 HStack{
@@ -114,7 +117,7 @@ struct DetailPageView: View {
     }
     
     @ViewBuilder
-    private var ReadingDate: some View {
+    var ReadingDate: some View {
         if let startDate = startDate, let endDate = endDate {
             let calendar = Calendar.current
             let startMonth = String(format: "%02d", calendar.component(.month, from: startDate))
@@ -166,14 +169,14 @@ struct DetailPageView: View {
 
     
     @ViewBuilder
-    private var ReadingProgress: some View{
+    var ReadingProgress: some View{
         VStack(alignment: .leading){
             Text("독서량")
-            ProgressView(value: Double(currentReadingPage), total: Double(pageNumber) ?? 0.0)
+            ProgressView(value: Double(currentReadingPage ?? 0), total: Double(pageNumber ?? "") ?? 0.0)
             HStack{
                 Text("0").font(.system(size: 13))
                 Spacer()
-                Text("\(currentReadingPage)/\(pageNumber)페이지")
+                Text("\(currentReadingPage ?? 0)/\(pageNumber ?? "")페이지")
                     .font(.system(size: 13))
             }
         }
@@ -181,15 +184,15 @@ struct DetailPageView: View {
     }
     
     @ViewBuilder
-    private var ExpectedScore: some View{
+    var ExpectedScore: some View{
         VStack(alignment: .leading){
             Text("기대점수")
-            ProgressView(value: Double(expectedScore), total: 10)
+            ProgressView(value: Double(expectedScore ?? 0), total: 10)
             HStack{
                 Text("0")
                     .font(.system(size: 13))
                 Spacer()
-                Text("\(expectedScore)/10점")
+                Text("\(expectedScore ?? 0)/10점")
                     .font(.system(size: 13))
             }
         }
@@ -197,7 +200,7 @@ struct DetailPageView: View {
     }
     
     @ViewBuilder
-    private var ButtonToggle: some View{
+    var ButtonToggle: some View{
         HStack {
             Button("책 정보") {
                 currentInfo = .bookInfo
@@ -220,7 +223,7 @@ struct DetailPageView: View {
     }
     
     @ViewBuilder
-    private func LabelInfo(title: String, subTitle: String)-> some View{
+    func LabelInfo(title: String, subTitle: String)-> some View{
         VStack(alignment: .leading){
             Text(title)
                 .fontWeight(.bold)
@@ -254,20 +257,20 @@ struct TopAppBar: View{
     }
 }
 
-struct DetailPageView_Previews: PreviewProvider {
-    static var previews: some View {
-        @State var selectedBooks = generateDetailMockBook(id: "1")
-        DetailPageView(title: selectedBooks.title,
-                       author: selectedBooks.author,
-                       pageNumber: selectedBooks.pageNumber,
-                       coverUrl: selectedBooks.coverUrl,
-                       description: selectedBooks.description,
-                       isbn: selectedBooks.isbn,
-                       publisher: selectedBooks.publisher,
-                       readingStatus: selectedBooks.readingStatus ?? .willRead,
-                       currentReadingPage: selectedBooks.currentReadingPage,
-                       expectedScore: selectedBooks.expectScore,
-                       startDate: selectedBooks.startDate!,
-                       endDate: selectedBooks.endDate!)
-    }
-}
+//struct DetailPageView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        @State var selectedBooks = generateDetailMockBook(id: "1")
+//        DetailPageView(title: selectedBooks.title,
+//                       author: selectedBooks.author,
+//                       pageNumber: selectedBooks.pageNumber,
+//                       coverUrl: selectedBooks.coverUrl,
+//                       description: selectedBooks.description,
+//                       isbn: selectedBooks.isbn,
+//                       publisher: selectedBooks.publisher,
+//                       readingStatus: selectedBooks.readingStatus ?? .willRead,
+//                       currentReadingPage: selectedBooks.currentReadingPage,
+//                       expectedScore: selectedBooks.expectScore,
+//                       startDate: selectedBooks.startDate!,
+//                       endDate: selectedBooks.endDate!)
+//    }
+//}

--- a/BookfelTower/BookfelTower/Home/DetailPage/SampleDetailView.swift
+++ b/BookfelTower/BookfelTower/Home/DetailPage/SampleDetailView.swift
@@ -1,0 +1,21 @@
+//
+//  SampleDetailView.swift
+//  BookfelTower
+//
+//  Created by Alex Cho on 2023/05/31.
+//
+import SwiftUI
+
+struct SampleDetailView: View {
+    let isbn: String
+
+    var body: some View {
+        Text(isbn)
+    }
+}
+
+struct SampleDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        SampleDetailView(isbn: "SAMPLE ISBN")
+    }
+}

--- a/BookfelTower/BookfelTower/Home/HomeView.swift
+++ b/BookfelTower/BookfelTower/Home/HomeView.swift
@@ -17,7 +17,7 @@ struct HomeView: View {
     
     var body: some View {
         
-        NavigationView {
+        NavigationStack {
             VStack(){
                 NavigationLink(destination: SearchPageView()){
                     HStack(){
@@ -32,9 +32,6 @@ struct HomeView: View {
                 .cornerRadius(8)
                 .padding(8)
                 .foregroundColor(Color(.systemGray))
-                .onTapGesture {
-                    
-                }
                 ScrollView{
                     Spacer(minLength: 300)
                     VStack(alignment: .center, spacing:1) {

--- a/BookfelTower/BookfelTower/Home/SearchPage/SearchPageView.swift
+++ b/BookfelTower/BookfelTower/Home/SearchPage/SearchPageView.swift
@@ -61,37 +61,41 @@ struct SearchCard: View{
     let publisher: String
     
     var body: some View{
-        HStack(spacing: 0){
-            AsyncImage(url: URL(string: coverUrl)) { image in image
-                    .resizable()
-                    .frame(width: DeviceSize.shouldSmallSize ? 100 : 110, height: DeviceSize.shouldSmallSize ? 130 : 140)
-            } placeholder: {
-                ProgressView()
-            }
-            ZStack(alignment: .leading){
-                Color.gray.opacity(0.2)
-                VStack(alignment: .leading){
-                    Text(title)
-                        .font(DeviceSize.shouldSmallSize ? .system(size: 15) : .system(size: 20))
-                        .fontWeight(.bold)
-                    Text(author)
-                        .foregroundColor(.gray)
-                        .font(DeviceSize.shouldSmallSize ? .system(size: 13) : .system(size: 17))
-                        .fontWeight(.bold)
-                    Text(description)
-                        .padding(.top, 5)
-                        .padding(.trailing, 10)
-                        .foregroundColor(.gray)
-                        .font(DeviceSize.shouldSmallSize ? .system(size: 10) : .system(size: 13))
-                    Spacer()
+//        NavigationLink(destination: SampleDetailView(isbn: self.isbn)){
+        NavigationLink(destination: DetailPageView(isbn: self.isbn, coverUrl: self.coverUrl)){
+            HStack(spacing: 0){
+                AsyncImage(url: URL(string: coverUrl)) { image in image
+                        .resizable()
+                        .frame(width: DeviceSize.shouldSmallSize ? 100 : 110, height: DeviceSize.shouldSmallSize ? 130 : 140)
+                } placeholder: {
+                    ProgressView()
                 }
-                .padding(.top, 10)
-                .padding(.horizontal, 20)
+                ZStack(alignment: .leading){
+                    Color.gray.opacity(0.2)
+                    VStack(alignment: .leading){
+                        Text(title)
+                            .font(DeviceSize.shouldSmallSize ? .system(size: 15) : .system(size: 20))
+                            .fontWeight(.bold)
+                        Text(author)
+                            .foregroundColor(.gray)
+                            .font(DeviceSize.shouldSmallSize ? .system(size: 13) : .system(size: 17))
+                            .fontWeight(.bold)
+                        Text(description)
+                            .padding(.top, 5)
+                            .padding(.trailing, 10)
+                            .foregroundColor(.gray)
+                            .font(DeviceSize.shouldSmallSize ? .system(size: 10) : .system(size: 13))
+                        Spacer()
+                    }
+                    .padding(.top, 10)
+                    .padding(.horizontal, 20)
+                }
             }
+            .frame(height: DeviceSize.shouldSmallSize ? 130 : 140)
+            .cornerRadius(20)
+            .padding(.horizontal, DeviceSize.shouldSmallSize ? 15 : 20)
         }
-        .frame(height: DeviceSize.shouldSmallSize ? 130 : 140)
-        .cornerRadius(20)
-        .padding(.horizontal, DeviceSize.shouldSmallSize ? 15 : 20)
+       
     }
 }
 struct BottomButton: View{


### PR DESCRIPTION
SearchCard 누를 시 ISBN을 넘기며 DetailPageView로 네비게이트합니다.

**🍎 Issue Number**
Close #27 

**🍏 작업 내역**
SearchCard 누를 시 ISBN을 넘기면서 DetailPageView로 네비게이션링크를 걸었습니다.
또한 DetailPageView에서 Private access level 사용시 부모 뷰인 서치페이지에서 이니셜라이즈 할 수 없는 문제가 생겼습니다.
따라서 private을 internal로 변경하였고 확실히 부모로부터 받을 수 있는 프로퍼티들은 let으로 선언하였습니다.

**🛠️ 작업 유형**
- [x] Feature 신규 기능 추가
- [x] Bug Fix 버그 수정
- [x] Refactoring 리팩토링

**📜 체크리스트**
- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

**⚠️ PR 특이 사항**
coverUrl 같은 경우 API 함수 완성시 필요 없으므로 지워야하며 일단 개발 편리성을 위해 넣어놨습니다.

**🖼️ 결과물 사진**

https://github.com/alexcho617/BookfelTower/assets/38528052/822f1967-0a39-4d4d-93a5-d03b74e3db58

